### PR TITLE
Add 'all' notification target – broadcast to every organisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,20 @@ Fahrzeug Cluster 12345 → Nachricht
 Fahrzeug Cluster 67890 → keine Nachricht
 ```
 
+## all
+
+Jede Statusänderung wird an **alle** konfigurierten Organisationen gesendet – pro Organisation ein eigener API-Aufruf mit den jeweils hinterlegten Empfängern (Gruppen oder Benutzer).
+
+Beispiel:
+
+```text
+Organisation A → Gruppen [101, 102]
+Organisation B → Benutzer [220053]
+Organisation C → Gruppen [305]
+
+→ Statusänderung eines beliebigen Fahrzeugs sendet Nachrichten an A, B und C
+```
+
 ---
 
 # Voraussetzungen

--- a/main.py
+++ b/main.py
@@ -98,8 +98,11 @@ def resolve_recipients(config, vehicle_cluster_id):
       "source"  → Empfänger aus der Organisation, zu der das Fahrzeug gehört
       "cluster" → Nur senden wenn Fahrzeug zur notification_target_cluster_id gehört,
                   Empfänger aus dieser Org
-    
-    Gibt zurück: (notification_type, groups_divera, users_primaerschluessel) oder None wenn nicht senden.
+      "all"     → Nachricht an alle konfigurierten Organisationen senden
+
+    Gibt zurück:
+      - Für "all": Liste von (notification_type, groups_divera, users_primaerschluessel, ucr_id)
+      - Sonst: (notification_type, groups_divera, users_primaerschluessel) oder None wenn nicht senden.
     """
     target = config.get("notification_target", "global")
     organizations = config.get("organizations", {})
@@ -142,6 +145,18 @@ def resolve_recipients(config, vehicle_cluster_id):
         if result is None:
             logger.warning(f"Keine Organisation für Cluster-ID {vehicle_cluster_id} gefunden. Nachricht wird nicht gesendet.")
         return result
+
+    elif target == "all":
+        # Nachricht an jede konfigurierte Organisation senden
+        results = []
+        for ucr_id, org in organizations.items():
+            results.append((
+                org.get("notification_type", "4"),
+                org.get("groups_divera", []),
+                org.get("users_primaerschluessel", []),
+                ucr_id
+            ))
+        return results if results else None
 
     return None
 
@@ -218,19 +233,28 @@ async def process_vehicle_message(message_data, ucr_id, cluster_id):
                 if should_send:
                     recipients = resolve_recipients(config, vehicle_cluster_id)
                     if recipients is not None:
-                        notification_type, groups_divera, users_primaerschluessel = recipients
                         message_text = (
                             f"Das Fahrzeug ({shortname}) hat in den Status: {fmsstatus} gewechselt.\n"
                             f" Fahrzeugname: {fullname},\n"
                             f" Kurzname: {shortname},\n"
                             f" FMS Status: {fmsstatus}\n"
                         )
-                        send_message(
-                            message_titel, message_text, private_mode, notification_type,
-                            send_push, send_mail, ts_publish, auto_archiv,
-                            archive_time(autoarchive_days, autoarchive_hours, autoarchive_minutes, autoarchive_seconds),
-                            groups_divera, users_primaerschluessel, api_key, ucr_id
-                        )
+                        ts_archive = archive_time(autoarchive_days, autoarchive_hours, autoarchive_minutes, autoarchive_seconds)
+                        # "all"-Modus liefert eine Liste mit (notification_type, groups, users, ucr_id)
+                        if isinstance(recipients, list):
+                            for notification_type, groups_divera, users_primaerschluessel, target_ucr_id in recipients:
+                                send_message(
+                                    message_titel, message_text, private_mode, notification_type,
+                                    send_push, send_mail, ts_publish, auto_archiv,
+                                    ts_archive, groups_divera, users_primaerschluessel, api_key, target_ucr_id
+                                )
+                        else:
+                            notification_type, groups_divera, users_primaerschluessel = recipients
+                            send_message(
+                                message_titel, message_text, private_mode, notification_type,
+                                send_push, send_mail, ts_publish, auto_archiv,
+                                ts_archive, groups_divera, users_primaerschluessel, api_key, ucr_id
+                            )
 
                 # Status aktualisieren
                 status_dict[vehicle_id] = fmsstatus
@@ -303,6 +327,8 @@ async def authenticate_and_listen():
     print(f"\nBenachrichtigungsmodus: {notification_target}")
     if notification_target == "cluster":
         print(f"Ziel-Cluster-ID: {config.get('notification_target_cluster_id')}")
+    elif notification_target == "all":
+        print(f"Nachricht wird an alle {len(organizations)} Organisation(en) gesendet.")
     print()
 
     # Pro Organisation eine eigene WebSocket-Task starten

--- a/setup.py
+++ b/setup.py
@@ -241,11 +241,12 @@ def create_config():
     print("  global  = Alle Statusänderungen → Empfänger der Hauptorganisation")
     print("  source  = Nachricht geht an die Org, aus der das Fahrzeug stammt")
     print("  cluster = Nur Fahrzeuge eines bestimmten Clusters melden")
+    print("  all     = Nachricht an alle konfigurierten Organisationen senden")
     while True:
         notification_target = input("Ziel eingeben (default: source): ").strip().lower() or "source"
-        if notification_target in ("global", "source", "cluster"):
+        if notification_target in ("global", "source", "cluster", "all"):
             break
-        print(f"  Ungültige Eingabe '{notification_target}' - bitte nur global, source oder cluster eingeben.")
+        print(f"  Ungültige Eingabe '{notification_target}' - bitte nur global, source, cluster oder all eingeben.")
     config["notification_target"] = notification_target
 
     config["notification_target_cluster_id"] = None


### PR DESCRIPTION
## Was wurde geändert

- Neuer Benachrichtigungsmodus `all` in `main.py`: Sendet bei jeder Statusänderung einen separaten API-Aufruf an **jede** konfigurierte Organisation – mit deren jeweiliger `ucr_id` und den hinterlegten Empfängern (Gruppen oder Benutzer).
- `resolve_recipients` gibt im `all`-Fall eine Liste von Tupeln `(notification_type, groups, users, ucr_id)` zurück; die Aufrufstelle erkennt dies per `isinstance(..., list)` und iteriert darüber.
- `setup.py`: `all` als gültige Eingabe ergänzt (Hinweistext + Validierung).
- `README.md`: Abschnitt `## all` mit Beschreibung und Beispiel hinzugefügt.

## Warum

Der bisherige `global`-Modus sendet immer nur an die erste Organisation. Mit `all` kann eine Statusmeldung gleichzeitig an Gruppen oder Benutzer mehrerer Organisationen zugestellt werden, ohne pro Organisation manuell einen separaten Kanal konfigurieren zu müssen.

## Hinweise für den Reviewer

- Die anderen Modi (`global`, `source`, `cluster`) sind nicht verändert worden.
- Pro Organisation in `config.json` kann weiterhin unabhängig gewählt werden, ob Gruppen (Typ 3) oder User (Typ 4) als Empfänger dienen.