### PR TITLE
Fix: Fahrzeug in Mode 1 sendet bei erstem Auftreten in Status 6 keine Nachricht

### DIFF
--- a/main.py
+++ b/main.py
@@ -214,7 +214,10 @@ async def process_vehicle_message(message_data, ucr_id, cluster_id):
                 
                 # Neu gesehenes Fahrzeug eintragen
                 if vehicle_id not in status_dict:
-                    status_dict[vehicle_id] = fmsstatus
+                    # Sentinel -1 für Mode 1: damit eine Transition nach Status 6 beim
+                    # ersten Auftreten korrekt erkannt wird, statt den Ist-Status als
+                    # "Vorher-Wert" zu setzen und die Änderungserkennung zu blockieren.
+                    status_dict[vehicle_id] = -1 if mode == 1 else fmsstatus
                     print(f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')} | Fahrzeug: {shortname} "
                           f"(Cluster: {vehicle_cluster_id}) hinzugefügt. Status: {fmsstatus}")
 


### PR DESCRIPTION
## Summary

- Bugfix in `process_vehicle_message`: Neues Fahrzeug wurde mit dem aktuellen `fmsstatus` als Vorher-Wert initialisiert
- Dadurch schlug die Änderungserkennung fehl wenn das Fahrzeug beim ersten Auftreten bereits in Status 6 war (Alt == Neu → kein Send)
- Fix: Sentinel-Wert `-1` für Mode 1, sodass der Übergang zu Status 6 auch beim ersten Auftreten korrekt erkannt wird

## Test plan

- [ ] Neues Fahrzeug in Status 6 → Nachricht wird gesendet
- [ ] Neues Fahrzeug in Status ≠ 6 → keine Nachricht
- [ ] Bekanntes Fahrzeug wechselt zu Status 6 → Nachricht wird gesendet (Regressionstest)
- [ ] Mode 2 und Mode 3 unverändert: neues Fahrzeug erhält aktuellen Status als Initialwert

🤖 Generated with [Claude Code](https://claude.com/claude-code)